### PR TITLE
Improve dropdown width behavior

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -433,6 +433,9 @@ if(jQuery) (function($) {
 				
 				// Auto-width
 				if( settings.autoWidth ) options.css('width', control.innerWidth());
+				else if(options.innerWidth() < control.innerWidth()) {
+					options.css('width', control.innerWidth() - parseInt(options.css('padding-left')) - parseInt(options.css('padding-right')))
+				}
 				
 				// Menu position
 				options.css({


### PR DESCRIPTION
When autoWidth is set to false, the dropdown options are now at least as large as the "a" tag. If the options content is larger than the "a" tag, the options are larger, just like a standard HTML select would do.
