### PR TITLE
fixing issue where arrow keys did not select the option

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -681,6 +681,7 @@ if(jQuery) (function($) {
 							}
 							
 							addHover(select, prev);
+							selectOption(select, prev, event);
 							keepOptionInView(select, prev);
 							
 						} else {
@@ -707,6 +708,7 @@ if(jQuery) (function($) {
 							}
 							
 							addHover(select, next);
+							selectOption(select, next, event);
 							keepOptionInView(select, next);
 							
 						} else {


### PR DESCRIPTION
To match normal browser behaviour the arrow keys should update the selected option when pressed.
