### PR TITLE
Keep focus on selection

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -387,6 +387,9 @@ if(jQuery) (function($) {
 									}
 									selectOption(select, $(this).parent());
 									hideMenus();
+									
+									// Give focus back to the original selectBox. This is native browser behaviour.
+									$(select).next('a.selectBox').focus();
 								}).bind('mouseover.selectBox', function(event) {
 									addHover(select, $(this).parent());
 								})


### PR DESCRIPTION
Natively browsers keep focus on a select element on change.

I've added the same functionality to the mouseup event.

This probably needs adding to the handleKeyDown events too.
