### PR TITLE
WAI-ARIA Accessibility updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 	<head>
+    	<meta charset="utf-8" />
 		<title>jQuery selectBox (select replacement plugin)</title>
 		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 		<script type="text/javascript" src="jquery.selectBox.js"></script>
-		<link type="text/css" rel="stylesheet" href="jquery.selectBox.css" />
+        <link type="text/css" rel="stylesheet" href="jquery.selectBox.css" />
 
 		<script type="text/javascript">
 
@@ -95,6 +96,13 @@
 						'menuSpeed' : 'fast'
 					});
 				});
+				
+				$("#loopOptions").click( function() {
+					$("SELECT").selectBox('settings', {
+						'loopOptions':$(this).val()=='true'
+					});
+					$(this).val(!($(this).val()=='true'));																		
+				});
 
 
 				$("SELECT")
@@ -122,7 +130,7 @@
 
 		<form style="background: #FFF; padding: 20px; border: solid 2px #DDD;">
 
-			<div id="console" style="width: 50%; font-family: 'Courier New', monospace; border: solid 2px #000; background: #000; color: #FFF; height: 350px; overflow: auto; padding: 10px; float: right;"></div>
+			<div id="console" style="width: 50%; font-family: 'Courier New', monospace; border: solid 2px #000; background: #000; color: #FFF; height: 350px; overflow: auto; padding: 10px; float: right;" role="log" aria-live="off" aria-atomic="true"></div>
 
 			<div style="background: #FFFCCC; border: solid 2px #DDD999; padding: 1px 10px; width: 50%; float: right; clear: right; margin: 1em 0;">
 				<p><strong>Note</strong></p>
@@ -138,11 +146,11 @@
 				</p>
 			</div>
 
-			<h1>$("SELECT").selectBox();</h1>
-
+			<h1>$(&quot;SELECT&quot;).selectBox();</h1>
+<div>
 			<p>
 				<label for="standard-dropdown">Standard Dropdown</label><br />
-				<select id="standard-dropdown" name="standard-dropdown" class="custom-class1 custom-class2" style="width: 200px;">
+				<select id="standard-dropdown" name="standard-dropdown" class="custom-class1 custom-class2 selectBox-Blue">
 					<option value="1" class="test-class-1">Item 1</option>
 					<option value="2" class="test-class-2" selected="selected">Item 2</option>
 					<option value="3" class="test-class-3">Item 3 has a really long label that will not interfere with the control's width</option>
@@ -164,16 +172,18 @@
 					<option value="19">Item 19</option>
 					<option value="20">Item 20</option>
 				</select>
+				<label id="standard-dropdown-second-label" for="standard-dropdown">Second label for Standard Dropdown</label>
 			</p>
 
 			<p>
-				Empty Dropdown<br />
-				<select name="empty-dropdown"></select>
+				<label>Empty Dropdown<br />
+				<select name="empty-dropdown" class="selectBox-Blue"></select>
+				</label>
 			</p>
 
 			<p>
 				<label for="multi-select-control">Multi-select Control</label><br />
-				<select id="multi-select-control" name="multi-select-control" multiple="multiple">
+				<select id="multi-select-control" name="multi-select-control" multiple="multiple" class="selectBox-Blue">
 					<option value="1" selected="selected">Item 1</option>
 					<option value="2">Item 2</option>
 					<option value="3">Item 3</option>
@@ -183,33 +193,78 @@
 			</p>
 
 			<p>
-				Empty Multi-select<br />
-				<select name="empty-multi-select" size="5" multiple="multiple"></select>
+				<label>Empty Multi-select<br />
+				<select name="empty-multi-select" size="5" multiple="multiple" class="selectBox-Blue"></select>
+				</label>
 			</p>
 
 			<p>
-				Multi-select with few options<br />
-				<select name="multi-select-few-options" multiple="multiple" size="5">
+				<label for="multi-select-few-options">Multi-select with few options<br />
+				<select id="multi-select-few-options" name="multi-select-few-options" multiple="multiple" size="5" class="selectBox-Blue">
 					<option value="1" selected="selected">Item 1</option>
 					<option value="2">Item 2</option>
 					<option value="3">Item 3</option>
 				</select>
+				</label>
 			</p>
 
 			<p>
-				No multi-select, size = 4<br />
-				<select name="no-multi-with-size-4" size="4">
+				<label>No multi-select, size = 4<br />
+				<select name="no-multi-with-size-4" size="4"  class="selectBox-Blue">
 					<option value="1" selected="selected">Item 1</option>
 					<option value="2">Item 2</option>
 					<option value="3">Item 3 has &lt;a&gt; really long label but it won't affect the control's display at all</option>
 					<option value="4">Item 4</option>
 					<option value="5" disabled="disabled">Item 5 (disabled)</option>
 				</select>
+				</label>
 			</p>
 
 			<p>
-				Standard control with OPTGROUPS<br />
-				<select name="standard-with-optgroups">
+				<label for="standard-with-optgroups">Standard control with OPTGROUPS</label><br />
+				<select id="standard-with-optgroups" name="standard-with-optgroups" class="selectBox-Gray">
+					<optgroup label="Section 1">
+						<option value="1">Item 1</option>
+						<option value="2">Item 2</option>
+						<option value="3">Item 3</option>
+						<option value="4">Item 4</option>
+					</optgroup>
+					<optgroup label="Section 2">
+						<option value="5">Item 5</option>
+						<option value="6">Item 6</option>
+						<option value="7">Item 7</option>
+						<option value="8">Item 8</option>
+					</optgroup>
+					<optgroup label="Section 3">
+						<option value="9">Item 9</option>
+						<option value="10">Item 10</option>
+						<option value="11">Item 11</option>
+						<option value="12">Item 12</option>
+					</optgroup>
+					<optgroup label="Section 4">
+						<option value="13">Item 13</option>
+						<option value="14">Item 14</option>
+						<option value="15">Item 15</option>
+						<option value="16">Item 16</option>
+					</optgroup>
+					<optgroup label="Section 5">
+						<option value="17">Item 17</option>
+						<option value="18">Item 18</option>
+						<option value="19">Item 19</option>
+						<option value="20">Item 20</option>
+					</optgroup>
+					<optgroup label="Section 6">
+						<option value="21">Item 21</option>
+						<option value="22">Item 22</option>
+						<option value="23">Item 23</option>
+						<option value="24">Item 24</option>
+					</optgroup>
+				</select>
+			</p>
+            
+            <p>
+				<label for="standard-with-optgroups-blue">Standard control with OPTGROUPS</label><br />
+				<select id="standard-with-optgroups-blue" name="standard-with-optgroups-blue" class="selectBox-Blue"  size="9">
 					<optgroup label="Section 1">
 						<option value="1">Item 1</option>
 						<option value="2">Item 2</option>
@@ -250,17 +305,17 @@
 			</p>
 
 			<p>
-				Multi-select control with OPTGROUPS<br />
-				<select name="multi-with-optgroups" multiple="multiple">
+				<label>Multi-select control with OPTGROUPS<br />
+				<select name="multi-with-optgroups" multiple="multiple" class="selectBox-Blue" size="9">
 					<optgroup label="Section 1">
 						<option value="1">Item 1</option>
-						<option value="2">Item 2</option>
+						<option value="2" selected="selected">Item 2</option>
 						<option value="3">Item 3</option>
 						<option value="4">Item 4</option>
 					</optgroup>
 					<optgroup label="Section 2">
 						<option value="5">Item 5</option>
-						<option value="6">Item 6</option>
+						<option value="6" selected="selected">Item 6</option>
 						<option value="7">Item 7</option>
 						<option value="8">Item 8</option>
 					</optgroup>
@@ -272,7 +327,7 @@
 					</optgroup>
 					<optgroup label="Section 4">
 						<option value="13">Item 13</option>
-						<option value="14">Item 14</option>
+						<option value="14" selected="selected">Item 14</option>
 						<option value="15">Item 15</option>
 						<option value="16">Item 16</option>
 					</optgroup>
@@ -285,15 +340,16 @@
 					<optgroup label="Section 6">
 						<option value="21">Item 21</option>
 						<option value="22">Item 22</option>
-						<option value="23">Item 23</option>
+						<option value="23" selected="selected">Item 23</option>
 						<option value="24">Item 24</option>
 					</optgroup>
 				</select>
+				</label>
 			</p>
 			
 			<p>
 				<label for="obscured-dropdown">Dropdown positioned above control</label> <br />
-				<select id="obscured-dropdown" name="obscured-dropdown" style="width: 200px">
+				<select id="obscured-dropdown" name="obscured-dropdown" style="width: 250px">
 					<option value="1" class="test-class-1">Item 1</option>
 					<option value="2" class="test-class-2" selected="selected">Item 2</option>
 					<option value="3" class="test-class-3">Item 3 has a really long label that will not interfere with the control's width</option>
@@ -316,7 +372,7 @@
 					<option value="20">Item 20</option>
 				</select>
 			</p>
-
+</div>
 			<hr align="left" style="height: 1px; background-color: #DDD; width: 40%; margin-top: 1.5em; border: 0;" />
 
 			<p>
@@ -341,6 +397,10 @@
 				<input type="button" id="default" value="Default" />
 				<input type="button" id="fade" value="Fade" />
 				<input type="button" id="slide" value="Slide" />
+			</p>
+            <p>
+				Loop options:
+				<input type="button" id="loopOptions" value="true" />
 			</p>
 
 			<div style="clear: both;"></div>

--- a/jquery.selectBox.css
+++ b/jquery.selectBox.css
@@ -23,12 +23,22 @@
 	cursor: default;
 }
 
+.selectBox-dropdown .selectBox-arrow {
+	-webkit-border-top-right-radius: 4px;
+    -webkit-border-bottom-right-radius: 4px;
+    -moz-border-radius-topright: 4px;
+    -moz-border-radius-bottomright: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
 .selectBox-dropdown:focus,
 .selectBox-dropdown:focus .selectBox-arrow {
 	border-color: #666;
 }
 
-.selectBox-dropdown.selectBox-menuShowing {
+.selectBox-dropdown.selectBox-menuShowing,
+.selectBox-dropdown.selectBox-menuShowing .selectBox-arrow  {
 	-moz-border-radius-bottomleft: 0;
 	-moz-border-radius-bottomright: 0;
 	-webkit-border-bottom-left-radius: 0;
@@ -50,25 +60,29 @@
 	right: 0;
 	width: 23px;
 	height: 100%;
-	background: url(jquery.selectBox-arrow.gif) 50% center no-repeat;
 	border-left: solid 1px #BBB;
 }
 
+.selectBox-dropdown .selectBox-arrow-icon {
+	position: absolute;
+    width:100%;
+    height:100%;
+    background: url(jquery.selectBox-arrow.gif) 50% center no-repeat;
+}
 
 /* Dropdown menu */
 .selectBox-dropdown-menu {
 	position: absolute;
 	z-index: 99999;
-	max-height: 200px;
-	min-height: 1em;
-	border: solid 1px #BBB; /* should be the same border width as .selectBox-dropdown */
+	max-height: 198px;
+	min-height: 1.5em;
+	border: 1px solid #BBB; /* should be the same border width as .selectBox-dropdown */
 	background: #FFF;
 	-moz-box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
 	-webkit-box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
 	box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
 	overflow: auto;
 }
-
 
 /* Inline control */
 .selectBox-inline {
@@ -87,11 +101,11 @@
 	border-color: #666;
 }
 
-
 /* Options */
 .selectBox-options,
 .selectBox-options LI,
-.selectBox-options LI A {
+.selectBox-options LI A,
+.selectBox-options UL {
 	list-style: none;
 	display: block;
 	cursor: default;
@@ -100,35 +114,44 @@
 }
 
 .selectBox-options LI A {
-	line-height: 1.5;
-	padding: 0 .5em;
+	line-height: 1.429em;
+	padding: 0 0.5em;
 	white-space: nowrap;
 	overflow: hidden;
-	background: 6px center no-repeat;
+	background: center no-repeat;
+    border: 1px solid transparent;
+    position: relative;
 }
 
 .selectBox-options LI.selectBox-hover A {
 	background-color: #EEE;
+    border: 1px solid #E8E8E8;
 }
 
 .selectBox-options LI.selectBox-disabled A {
-	color: #888;
-	background-color: transparent;
+	color: #888 !important;
+	background-color: transparent !important;
+    border-color: transparent !important;
 }
 
 .selectBox-options LI.selectBox-selected A {
 	background-color: #C8DEF4;
 }
 
-.selectBox-options .selectBox-optgroup {
+.selectBox-options LI.selectBox-hover.selectBox-selected A {
+	border: 1px solid #A8BED4;
+}
+
+.selectBox-options .selectBox-optgroup>span {
 	color: #666;
 	background: #EEE;
+    border: 1px solid #EEE;
 	font-weight: bold;
 	line-height: 1.5;
 	padding: 0 .3em;
 	white-space: nowrap;
+	display:block;
 }
-
 
 /* Disabled state */
 .selectBox.selectBox-disabled {
@@ -147,4 +170,183 @@
 
 .selectBox-inline.selectBox-disabled .selectBox-options A {
 	background-color: transparent !important;
+}
+
+/* CSS Animation */
+@keyframes selectBox-multiselect-animation {
+    0% {
+    	border-color: #EEE;
+    }
+    50% {
+    	border-color: #BBB;
+    }
+    100% {
+    	border-color: #EEE;
+    }
+}
+@-webkit-keyframes selectBox-multiselect--webkit-animation {
+    0% {
+    	border-color: #EEE;
+    }
+    50% {
+    	border-color: #BBB;
+    }
+    100% {
+    	border-color: #EEE;
+    }
+}
+@-moz-keyframes selectBox-multiselect--moz-animation {
+    0% {
+    	border-color: #EEE;
+    }
+    50% {
+    	border-color: #BBB;
+    }
+    100% {
+    	border-color: #EEE;
+    }
+}
+@-ms-keyframes selectBox-multiselect--ms-animation {
+    0% {
+    	border-color: #EEE;
+    }
+    50% {
+    	border-color: #BBB;
+    }
+    100% {
+    	border-color: #EEE;
+    }
+}
+@-o-keyframes selectBox-multiselect--o-animation {
+    0% {
+    	border-color: #EEE;
+    }
+    50% {
+    	border-color: #BBB;
+    }
+    100% {
+    	border-color: #EEE;
+    }
+}
+
+@keyframes selectBox-multiselect-selected-animation {
+    0% {
+    	border-color: #C8DEF4;
+    }
+    50% {
+    	border-color: #A8BED4;
+    }
+    100% {
+    	border-color: #C8DEF4;
+    }
+}
+@-webkit-keyframes selectBox-multiselect-selected--webkit-animation {
+    0% {
+    	border-color: #C8DEF4;
+    }
+    50% {
+    	border-color: #A8BED4;
+    }
+    100% {
+    	border-color: #C8DEF4;
+    }
+}
+@-moz-keyframes selectBox-multiselect-selected--moz-animation {
+    0% {
+    	border-color: #C8DEF4;
+    }
+    50% {
+    	border-color: #A8BED4;
+    }
+    100% {
+    	border-color: #C8DEF4;
+    }
+}
+@-ms-keyframes selectBox-multiselect-selected--ms-animation {
+    0% {
+    	border-color: #C8DEF4;
+    }
+    50% {
+    	border-color: #A8BED4;
+    }
+    100% {
+    	border-color: #C8DEF4;
+    }
+}
+@-o-keyframes selectBox-multiselect-selected--o-animation {
+    0% {
+    	border-color: #C8DEF4;
+    }
+    50% {
+    	border-color: #A8BED4;
+    }
+    100% {
+    	border-color: #C8DEF4;
+    }
+}
+
+.selectBox-multiselect .selectBox-options LI.selectBox-hover A {
+    animation-name: selectBox-multiselect-animation;
+    animation-duration: 1.5s;
+    animation-iteration-count: infinite;
+    animation-timing-function: ease-in-out;
+    animation-fill-mode: none;
+    animation-direction: normal;
+    -webkit-animation-name: selectBox-multiselect--webkit-animation;
+    -webkit-animation-duration: 1.5s;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-timing-function: ease-in-out;
+    -webkit-animation-fill-mode: none;
+    -webkit-animation-direction: normal;
+    -moz-animation-name: selectBox-multiselect--moz-animation;
+    -moz-animation-duration: 1.5s;
+    -moz-animation-iteration-count: infinite;
+    -moz-animation-timing-function: ease-in-out;
+    -moz-animation-fill-mode: none;
+    -moz-animation-direction: normal;
+    -ms-animation-name: selectBox-multiselect--ms-animation;
+    -ms-animation-duration: 1.5s;
+    -ms-animation-iteration-count: infinite;
+    -ms-animation-timing-function: ease-in-out;
+    -ms-animation-fill-mode: none;
+    -ms-animation-direction: normal;
+    -o-animation-name: selectBox-multiselect--o-animation;
+    -o-animation-duration: 1.5s;
+    -o-animation-iteration-count: infinite;
+    -o-animation-timing-function: ease-in-out;
+    -o-animation-fill-mode: none;
+    -o-animation-direction: normal;
+}
+
+.selectBox-multiselect .selectBox-options LI.selectBox-hover.selectBox-selected A {
+    animation-name: selectBox-multiselect-selected-animation;
+    animation-duration: 1.5s;
+    animation-iteration-count: infinite;
+    animation-timing-function: ease-in-out;
+    animation-fill-mode: none;
+    animation-direction: normal;
+    -webkit-animation-name: selectBox-multiselect-selected--webkit-animation;
+    -webkit-animation-duration: 1.5s;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-timing-function: ease-in-out;
+    -webkit-animation-fill-mode: none;
+    -webkit-animation-direction: normal;
+    -moz-animation-name: selectBox-multiselect-selected--moz-animation;
+    -moz-animation-duration: 1.5s;
+    -moz-animation-iteration-count: infinite;
+    -moz-animation-timing-function: ease-in-out;
+    -moz-animation-fill-mode: none;
+    -moz-animation-direction: normal;
+    -ms-animation-name: selectBox-multiselect-selected--ms-animation;
+    -ms-animation-duration: 1.5s;
+    -ms-animation-iteration-count: infinite;
+    -ms-animation-timing-function: ease-in-out;
+    -ms-animation-fill-mode: none;
+    -ms-animation-direction: normal;
+    -o-animation-name: selectBox-multiselect-selected--o-animation;
+    -o-animation-duration: 1.5s;
+    -o-animation-iteration-count: infinite;
+    -o-animation-timing-function: ease-in-out;
+    -o-animation-fill-mode: none;
+    -o-animation-direction: normal;
 }

--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -17,7 +17,6 @@ if (jQuery)(function($) {
 			// Private methods
 			//
 			var init = function(select, data) {
-					var options;
 					// Disable for iOS devices (their native controls are more suitable for a touch device)
 					if (navigator.userAgent.match(/iPad|iPhone|Android|IEMobile|BlackBerry/i)) return false;
 					// Element must be a select control
@@ -25,41 +24,99 @@ if (jQuery)(function($) {
 					select = $(select);
 					if (select.data('selectBox-control')) return false;
 					var control = $('<a class="selectBox" />'),
-						inline = select.attr('multiple') || parseInt(select.attr('size')) > 1;
-					var settings = data || {};
-					control.width(select.outerWidth()).addClass(select.attr('class')).attr('title', select.attr('title') || '').attr('tabindex', parseInt(select.attr('tabindex'))).css('display', 'inline-block').bind('focus.selectBox', function() {
-						if (this !== document.activeElement && document.body !== document.activeElement) $(document.activeElement).blur();
-						if (control.hasClass('selectBox-active')) return;
-						control.addClass('selectBox-active');
-						select.trigger('focus');
-					}).bind('blur.selectBox', function() {
-						if (!control.hasClass('selectBox-active')) return;
-						control.removeClass('selectBox-active');
-						select.trigger('blur');
-					});
+						options,
+						settings = data || {},
+						multiple = !!select.attr('multiple'),
+						inline = multiple || parseInt(select.attr('size')) > 1,
+						lastSelected,
+						formLabel, 
+						ariaLabelledBy = ''; 
+					select.data('_tmp',0); /* Add temporary data so that $.expando variable gets created, which provides an id for the select box */
+					control
+						.width(select.outerWidth())
+						.addClass(select.attr('class'))
+						.attr('id','selectBox-control-'+(select.attr('id') ? select.attr('id') : select[0][$.expando]))
+						.attr('tabindex', parseInt(select.attr('tabindex')))
+						.css('display', 'inline-block')
+						.bind('focus.selectBox', function() {
+							if (this !== document.activeElement && document.body !== document.activeElement) $(document.activeElement).blur();
+							if (control.hasClass('selectBox-active')) return;
+							control.addClass('selectBox-active');
+							if (control.data('selectBox-last-selected')) addHover(select,control.data('selectBox-last-selected'));
+							select.trigger('focus');
+						})
+						.bind('blur.selectBox', function() {
+							if (!control.hasClass('selectBox-active')) return;
+							control.removeClass('selectBox-active').removeClass('selectBox-multiselect');
+							select.trigger('blur');
+						});
 					if (!$(window).data('selectBox-bindings')) {
 						$(window).data('selectBox-bindings', true).bind('scroll.selectBox', hideMenus).bind('resize.selectBox', hideMenus);
 					}
-					if (select.attr('disabled')) control.addClass('selectBox-disabled');
+					
+					// Add title to control, but only if attribute exists on the select */
+					if (select.attr('title')) control.attr('title', select.attr('title')); 
+					// Add selectBox-disabled class and aria-disabled attribute to control if disabled attribute exists
+					if (select.attr('disabled')) control.addClass('selectBox-disabled').attr('aria-disabled',true); 
+					
+					// Find any labels associated with the select, give them id's if neccessary, and add them to the control using aria-labelledby attribute.			
+					$( 'label[for="'+select.attr('id')+'"]' )
+						.each(function(index, element) {
+							if (!element.id) element.id = control.attr('id')+'-label'+index;
+							ariaLabelledBy = control.attr('aria-labelledby')||'';
+							ariaLabelledBy = ariaLabelledBy.length ? ariaLabelledBy+' '+element.id : element.id;
+							control.attr('aria-labelledby',ariaLabelledBy)
+						});	
+					
+					// Find any parent label of the select, give it an id if neccessary, and add it to the control using aria-labelledby attribute.
+					select.closest('label')
+						.each(function(index, element) {
+							if (!element.id) element.id = control.attr('id')+'-label'+index;
+							ariaLabelledBy = control.attr('aria-labelledby')||'';
+							ariaLabelledBy = ariaLabelledBy.length?ariaLabelledBy+' '+element.id:element.id;
+							control.attr('aria-labelledby',ariaLabelledBy)
+						});
+					
+					// If the select has an aria-labelledby attribute, append it to the controls's aria-labelledby attribute.
+					if (select.attr('aria-labelledby'))
+					{
+						ariaLabelledBy = control.attr('aria-labelledby')||'';
+						ariaLabelledBy = ariaLabelledBy.length ? ariaLabelledBy+' '+select.attr('aria-labelledby') : select.attr('aria-labelledby');
+						control.attr('aria-labelledby',ariaLabelledBy);
+					}
+					
+					// If the select has an aria-label attribute, add it to the control.
+					if (select.attr('aria-label')) control.attr('aria-label',select.attr('aria-label'));
+					
 					// Focus on control when label is clicked
 					select.bind('click.selectBox', function(event) {
 						control.focus();
 						event.preventDefault();
 					});
+					
 					// Generate control
 					if (inline) {
 						//
 						// Inline controls
 						//
 						options = getOptions(select, 'inline');
-						control.append(options).data('selectBox-options', options).addClass('selectBox-inline selectBox-menuShowing').bind('keydown.selectBox', function(event) {
-							handleKeyDown(select, event);
-						}).bind('keypress.selectBox', function(event) {
-							handleKeyPress(select, event);
-						}).bind('mousedown.selectBox', function(event) {
-							if ($(event.target).is('A.selectBox-inline')) event.preventDefault();
-							if (!control.hasClass('selectBox-focus')) control.focus();
-						}).insertAfter(select);
+						control
+							.attr('role','listbox')
+							.attr('aria-multiselectable',multiple)
+							.append(options)
+							.data('selectBox-options', options)
+							.addClass('selectBox-inline selectBox-menuShowing')
+							.bind('keydown.selectBox', function(event) {
+								handleKeyDown(select, event);
+							})
+							.bind('keypress.selectBox', function(event) {
+								handleKeyPress(select, event);
+							})
+							.bind('mousedown.selectBox', function(event) {
+								if ($(event.target).is('A.selectBox-inline')) event.preventDefault();
+								if (!control.hasClass('selectBox-active')) control.focus();
+							})
+							.insertAfter(select);
 						// Auto-height based on size attribute
 						if (!select[0].style.height) {
 							var size = select.attr('size') ? parseInt(select.attr('size')) : 5;
@@ -79,105 +136,158 @@ if (jQuery)(function($) {
 						// Dropdown controls
 						//
 						var label = $('<span class="selectBox-label" />'),
-							arrow = $('<span class="selectBox-arrow" />');
+							arrow = $('<span class="selectBox-arrow"><span class="selectBox-arrow-icon"></span></span>');
 						// Update label
-						label.attr('class', getLabelClass(select)).text(getLabelText(select));
+						label.attr('id','selectBox-label-'+control.attr('id'))
+							.attr('class', getLabelClass(select))
+							.text(getLabelText(select));
 						options = getOptions(select, 'dropdown');
-						options.appendTo('BODY');
-						control.data('selectBox-options', options).addClass('selectBox-dropdown').append(label).append(arrow).bind('mousedown.selectBox', function(event) {
-							if (control.hasClass('selectBox-menuShowing')) {
-								hideMenus();
-							} else {
-								event.stopPropagation();
-								// Webkit fix to prevent premature selection of options
-								options.data('selectBox-down-at-x', event.screenX).data('selectBox-down-at-y', event.screenY);
+						// Include the label as part of the control's label
+						ariaLabelledBy = ariaLabelledBy.length?label.attr('id')+' '+ariaLabelledBy:label.attr('id'); 
+						control
+							.attr('role', 'combobox')
+							.attr('aria-readonly', true)
+							.attr('aria-expanded', false)
+							.attr('aria-owns', 'selectBox-dropdown-menu-'+(select.attr('id') ? select.attr('id') : select[0][$.expando]))
+							.attr('aria-labelledby', ariaLabelledBy)
+							.data('selectBox-options', options)
+							.addClass('selectBox-dropdown')
+							.append(label)
+							.append(arrow)
+							.bind('mousedown.selectBox', function(event) {
+								if (control.hasClass('selectBox-menuShowing')) {
+									hideMenus();
+								} else {
+									event.stopPropagation();
+									// Webkit fix to prevent premature selection of options
+									options.data('selectBox-down-at-x', event.screenX).data('selectBox-down-at-y', event.screenY);
+									showMenu(select);
+								}
+							})
+							.bind('keydown.selectBox', function(event) {
+								handleKeyDown(select, event);
+							})
+							.bind('keypress.selectBox', function(event) {
+								handleKeyPress(select, event);
+							})
+							.bind('open.selectBox', function(event, triggerData) {
+								if (triggerData && triggerData._selectBox === true) return;
 								showMenu(select);
-							}
-						}).bind('keydown.selectBox', function(event) {
-							handleKeyDown(select, event);
-						}).bind('keypress.selectBox', function(event) {
-							handleKeyPress(select, event);
-						}).bind('open.selectBox', function(event, triggerData) {
-							if (triggerData && triggerData._selectBox === true) return;
-							showMenu(select);
-						}).bind('close.selectBox', function(event, triggerData) {
-							if (triggerData && triggerData._selectBox === true) return;
-							hideMenus();
-						}).insertAfter(select);
+							})
+							.bind('close.selectBox', function(event, triggerData) {
+								if (triggerData && triggerData._selectBox === true) return;
+								hideMenus();
+							})
+							.insertAfter(select);
+						
+						// Options are added to the DOM immediately after the control
+						options.attr('aria-labelledby',ariaLabelledBy)
+							.insertAfter(control);
+																		
 						// Set label width
 						var labelWidth = control.width() - arrow.outerWidth() - parseInt(label.css('paddingLeft')) - parseInt(label.css('paddingLeft'));
 						label.width(labelWidth);
 						disableSelection(control);
 					}
+					
 					// Store data for later use and show the control
-					select.addClass('selectBox').data('selectBox-control', control).data('selectBox-settings', settings).hide();
+					select.removeData('_tmp')
+						.addClass('selectBox')
+						.data('selectBox-control', control)
+						.data('selectBox-settings', settings)
+						.hide();
+						
+					// Store the last selected element to set cursor index position 
+					lastSelected = options.find('.selectBox-selected').last();
+					if (lastSelected.length) {
+						control.data('selectBox-last-selected',lastSelected);
+						control.attr('aria-activedescendant',lastSelected.attr('id'));
+						keepOptionInView(select, lastSelected, true);
+					}
 				};
 			var getOptions = function(select, type) {
-					var options;
-					// Private function to handle recursion in the getOptions function.
-					var _getOptions = function(select, options) {
+					var options, option, i=0
+					/* Private function to handle recursion in the getOptions function. */
+						_getOptions = function(select, options) {
 							// Loop through the set in order of element children.
 							select.children('OPTION, OPTGROUP').each(function() {
 								// If the element is an option, add it to the list.
 								if ($(this).is('OPTION')) {
+									var parentNode =$(this).parent().is('OPTGROUP') ? options.find('.selectBox-optgroup:last ul') : options;
 									// Check for a value in the option found.
 									if ($(this).length > 0) {
-										// Create an option form the found element.
-										generateOptions($(this), options);
+										// Create an option for the found element.
+										option = generateOption($(this), parentNode);
+										option.find('A').attr('id',options.attr('id')+'-'+(i++));
 									} else {
 										// No option information found, so add an empty.
-										options.append('<li>\u00A0</li>');
+										parentNode.append('<li role="presentation"><a>\u00A0</a></li>')
 									}
 								} else {
 									// If the element is an option group, add the group and call this function on it.
-									var optgroup = $('<li class="selectBox-optgroup" />');
-									optgroup.text($(this).attr('label'));
+									// The optgroup heading is a span element which labels a nested list containing the options.
+									i++;
+									var optgroup = $('<li id="selectBox-optgroup-'+i+'" class="selectBox-optgroup" role="presentation" />')
+									.append('<span id="selectBox-optgroup-'+i+'-label">'+$(this).attr('label')+'</span>')
+									.append('<ul aria-labelledby="selectBox-optgroup-'+i+'-label"></ul>');
 									options.append(optgroup);
 									options = _getOptions($(this), options);
 								}
 							});
-							// Return the built strin
+							// Return the built string
 							return options;
 						};
 					switch (type) {
 					case 'inline':
-						options = $('<ul class="selectBox-options" />');
+						options = $('<ul class="selectBox-options" role="presentation" />');
+						options.attr('id','selectBox-menu-'+(select.attr('id')?select.attr('id'):select[0][$.expando]));
 						options = _getOptions(select, options);
-						options.find('A').bind('mouseover.selectBox', function(event) {
-							addHover(select, $(this).parent());
-						}).bind('mouseout.selectBox', function(event) {
-							removeHover(select, $(this).parent());
-						}).bind('mousedown.selectBox', function(event) {
-							event.preventDefault(); // Prevent options from being "dragged"
-							if (!select.selectBox('control').hasClass('selectBox-active')) select.selectBox('control').focus();
-						}).bind('mouseup.selectBox', function(event) {
-							hideMenus();
-							selectOption(select, $(this).parent(), event);
-						});
+						options.find('A')
+							.bind('mouseover.selectBox', function(event) {
+								addHover(select, $(this).parent());
+							})
+							.bind('mouseout.selectBox', function(event) {
+								removeHover(select, $(this).parent());
+							})
+							.bind('mousedown.selectBox', function(event) {
+								event.preventDefault(); // Prevent options from being "dragged"
+								if (!select.selectBox('control').hasClass('selectBox-active')) select.selectBox('control').focus();
+							})
+							.bind('mouseup.selectBox', function(event) {
+								hideMenus();
+								addHover(select, $(this).parent());
+								selectOption(select, $(this).parent(), event);
+								keepOptionInView(select, $(this).parent());
+							});
 						disableSelection(options);
 						return options;
 					case 'dropdown':
-						options = $('<ul class="selectBox-dropdown-menu selectBox-options" />');
+						options = $('<ul class="selectBox-dropdown-menu selectBox-options" role="listbox" />');
+						options.attr('id','selectBox-dropdown-menu-'+(select.attr('id')?select.attr('id'):select[0][$.expando]));
 						options = _getOptions(select, options);
-						options.data('selectBox-select', select).css('display', 'none').appendTo('BODY').find('A').bind('mousedown.selectBox', function(event) {
-							event.preventDefault(); // Prevent options from being "dragged"
-							if (event.screenX === options.data('selectBox-down-at-x') && event.screenY === options.data('selectBox-down-at-y')) {
-								options.removeData('selectBox-down-at-x').removeData('selectBox-down-at-y');
+						options.data('selectBox-select', select).css('display','none').find('A')
+							.bind('mousedown.selectBox', function(event) {
+								event.preventDefault(); // Prevent options from being "dragged"
+								if (event.screenX === options.data('selectBox-down-at-x') && event.screenY === options.data('selectBox-down-at-y')) {
+									options.removeData('selectBox-down-at-x').removeData('selectBox-down-at-y');
+									hideMenus();
+								}
+							})
+							.bind('mouseup.selectBox', function(event) {
+								if (event.screenX === options.data('selectBox-down-at-x') && event.screenY === options.data('selectBox-down-at-y')) {
+									return;
+								} else {
+									options.removeData('selectBox-down-at-x').removeData('selectBox-down-at-y');
+								}
+								selectOption(select, $(this).parent(), event);
 								hideMenus();
-							}
-						}).bind('mouseup.selectBox', function(event) {
-							if (event.screenX === options.data('selectBox-down-at-x') && event.screenY === options.data('selectBox-down-at-y')) {
-								return;
-							} else {
-								options.removeData('selectBox-down-at-x').removeData('selectBox-down-at-y');
-							}
-							selectOption(select, $(this).parent());
-							hideMenus();
-						}).bind('mouseover.selectBox', function(event) {
-							addHover(select, $(this).parent());
-						}).bind('mouseout.selectBox', function(event) {
-							removeHover(select, $(this).parent());
-						});
+							})
+							.bind('mouseover.selectBox', function(event) {
+								addHover(select, $(this).parent());
+							})
+							.bind('mouseout.selectBox', function(event) {
+								removeHover(select, $(this).parent());
+							});
 						// Inherit classes for dropdown menu
 						var classes = select.attr('class') || '';
 						if (classes !== '') {
@@ -248,10 +358,10 @@ if (jQuery)(function($) {
 					}
 					if (!settings.menuSpeed) dispatchOpenEvent();
 					// Center on selected option
-					var li = options.find('.selectBox-selected:first');
+					var li = control.data('selectBox-last-selected') ? control.data('selectBox-last-selected') : options.find('.selectBox-selected:last');
 					keepOptionInView(select, li, true);
 					addHover(select, li);
-					control.addClass('selectBox-menuShowing');
+					control.addClass('selectBox-menuShowing').attr('aria-expanded',true);
 					$(document).bind('mousedown.selectBox', function(event) {
 						if ($(event.target).parents().andSelf().hasClass('selectBox-options')) return;
 						hideMenus();
@@ -264,13 +374,17 @@ if (jQuery)(function($) {
 						var options = $(this),
 							select = options.data('selectBox-select'),
 							control = select.data('selectBox-control'),
-							settings = select.data('selectBox-settings');
+							settings = select.data('selectBox-settings'),
+							lastSelected =options.find('.selectBox-selected');
 						if (select.triggerHandler('beforeclose')) return false;
 						var dispatchCloseEvent = function() {
 								select.triggerHandler('close', {
 									_selectBox: true
 								});
 							};
+						// Restore last selected as active descendant
+						control.data('selectBox-last-selected', lastSelected).attr('aria-expanded',false).attr('aria-activedescendant',lastSelected.find('A').attr('id'));
+						options.attr('aria-activedescendant',control.attr('aria-activedescendant'));
 						if (settings) {
 							switch (settings.menuTransition) {
 							case 'fade':
@@ -298,36 +412,136 @@ if (jQuery)(function($) {
 					select = $(select);
 					li = $(li);
 					var control = select.data('selectBox-control'),
-						settings = select.data('selectBox-settings');
+						settings = select.data('selectBox-settings'),
+						options = control.data('selectBox-options'),
+						lis = options.find('li:not(.selectBox-optgroup, .selectBox-disabled)'),
+						lastSelected = control.data('selectBox-last-selected'),
+						dir = -1,
+						affectedOptions,
+						selectedOptions;
 					if (control.hasClass('selectBox-disabled')) return false;
 					if (li.length === 0 || li.hasClass('selectBox-disabled')) return false;
 					if (select.attr('multiple')) {
 						// If event.shiftKey is true, this will select all options between li and the last li selected
-						if (event.shiftKey && control.data('selectBox-last-selected')) {
+						if (event.shiftKey && lastSelected) {
 							li.toggleClass('selectBox-selected');
-							var affectedOptions;
-							if (li.index() > control.data('selectBox-last-selected').index()) {
-								affectedOptions = li.siblings().slice(control.data('selectBox-last-selected').index(), li.index());
+							if (li.hasClass('selectBox-selected')) {
+								li.find('A').attr('aria-selected',true);
 							} else {
-								affectedOptions = li.siblings().slice(li.index(), control.data('selectBox-last-selected').index());
+								li.find('A').removeAttr('aria-selected');
+							}
+							var affectedOptions;
+							if (lis.index(li) > lis.index(lastSelected)) {
+								affectedOptions = lis.slice(lis.index(lastSelected), lis.index(li));
+							} else {
+								affectedOptions = lis.slice(lis.index(li), lis.index(lastSelected)+1);
 							}
 							affectedOptions = affectedOptions.not('.selectBox-optgroup, .selectBox-disabled');
 							if (li.hasClass('selectBox-selected')) {
-								affectedOptions.addClass('selectBox-selected');
+								affectedOptions.addClass('selectBox-selected').find('A').attr('aria-selected',true);
 							} else {
-								affectedOptions.removeClass('selectBox-selected');
+								affectedOptions.removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
 							}
-						} else if ((isMac && event.metaKey) || (!isMac && event.ctrlKey)) {
-							li.toggleClass('selectBox-selected');
+							if (event.type=='keydown')
+							{
+								switch (event.keyCode)
+								{
+									case 37: // left
+									case 38: // up
+									{
+										dir = 1;
+										break;
+									}
+									case 39: // right
+									case 40: // down
+									{
+										dir = 0;
+										break;
+									}
+								}
+															
+								if (affectedOptions.index(lastSelected)==dir)
+								{
+									if (li.hasClass('selectBox-selected') && !lastSelected.hasClass('selectBox-selected')) {
+										li.removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
+									} else {
+										li.addClass('selectBox-selected').find('A').attr('aria-selected',true);
+									}
+								}
+								
+								if (event.keyCode != 13 && event.keyCode != 32)
+								{
+									/*
+									 * The following block restricts selection with the shiftKey to contiguous selection
+									 */
+									selectedOptions = options.find('.selectBox-selected');
+									
+									var startSelected = selectedOptions.index(li), /* the index current selection within array of selected options */
+										startLi = lis.index(li), /* the index of the current selection within all selectable options */ 
+										lastIndex = startLi, /* the last index for comparison */
+										testIndex, /* the current index for comparison */
+										i, /* an iterator */ 
+										contiguous=true /* boolean indication of contiguous selection */;
+									
+									/* first loop backwards through selected elements 
+									   before the current selection */
+									for(i=startSelected; i>=0; i--)
+									{
+										testIndex = lis.index(selectedOptions.eq(i));
+										/* if the distance between the current selected option 
+										   and the last selected option is greater than 1, they are not contiguous */ 
+										if (Math.abs(testIndex-lastIndex)>1) 
+											contiguous = false;
+										/* if they're are not contiguous, any previous selections should be deselected */ 
+										if (!contiguous)
+											selectedOptions.eq(i).removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
+										lastIndex = testIndex; 
+									}
+									
+									/* next, reset contiguous to true and loop forward through selected elements
+									   starting with the current selection */
+									contiguous=true;
+									lastIndex=startLi;
+									for(i=startSelected; i<selectedOptions.length; i++)
+									{
+										testIndex = lis.index(selectedOptions.eq(i))
+										/* if the distance between the current selected option 
+										   and the last selected option is greater than 1, they are not contiguous */ 
+										if (Math.abs(testIndex-lastIndex)>1)
+											contiguous = false;
+										/* if they're are not contiguous, any further selections should be deselected */ 
+										if (!contiguous)
+											selectedOptions.eq(i).removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
+										lastIndex = testIndex; 
+									}
+								}
+							}													
+						} else if ((isMac && event.metaKey) 
+									|| (!isMac && event.ctrlKey) 
+									|| control.hasClass('selectBox-multiselect') /* SHIFT+F8 multiselect mode toggled */) {
+							if (event.type!='keydown' /* CTRL+CLICK */
+								|| (event.keyCode==13 /* CTRL+ENTER */ || event.keyCode==32 /* CTRL+SPACE */  || event.keyCode==65 /* CTRL+A */)) {
+								if (event.keyCode==65) {
+									li.addClass('selectBox-selected');
+								} else {
+									li.toggleClass('selectBox-selected');
+								}
+								if (li.hasClass('selectBox-selected')) {
+									li.find('A').attr('aria-selected',true);
+								} else {
+									li.find('A').removeAttr('aria-selected');
+								}
+							}
 						} else {
-							li.siblings().removeClass('selectBox-selected');
-							li.addClass('selectBox-selected');
+							lis.removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
+							li.addClass('selectBox-selected').find('A').attr('aria-selected',true);
 						}
-					} else {
-						li.siblings().removeClass('selectBox-selected');
-						li.addClass('selectBox-selected');
+					} else if (event.type!='keydown' || !((isMac && event.metaKey) || (!isMac && event.ctrlKey))) {
+						lis.removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
+						li.addClass('selectBox-selected').find('A').attr('aria-selected',true);
 					}
-					if (control.hasClass('selectBox-dropdown')) {
+					// Update the control's label
+					if (control.hasClass('selectBox-dropdown') && li.hasClass('selectBox-selected')) {
 						control.find('.selectBox-label').text(li.text());
 					}
 					// Update original control's value
@@ -338,10 +552,11 @@ if (jQuery)(function($) {
 							selection[i++] = $(this).attr('rel');
 						});
 					} else {
-						selection = li.find('A').attr('rel');
+						selection = options.find('.selectBox-selected A').attr('rel');
 					}
 					// Remember most recently selected item
-					control.data('selectBox-last-selected', li);
+					control.data('selectBox-last-selected', li).attr('aria-activedescendant',li.find('A').attr('id'));
+					options.attr('aria-activedescendant',control.attr('aria-activedescendant'));
 					// Change callback
 					if (select.val() !== selection) {
 						select.val(selection);
@@ -393,8 +608,15 @@ if (jQuery)(function($) {
 						options = control.data('selectBox-options'),
 						settings = select.data('selectBox-settings'),
 						totalOptions = 0,
-						i = 0;
-					if (control.hasClass('selectBox-disabled')) return;
+						i = 0,
+						currentIndex = 0,						
+						selectableOptions = options.find('LI:not(.selectBox-optgroup, .selectBox-disabled)'),
+						lis = options.find('LI'),
+						lastSelected = control.data('selectBox-last-selected'),
+						lastHovered = options.find('.selectBox-hover:first'),
+						multiple = !!select.attr('multiple'),
+						pageHeight, optionHeight, size;
+					if (control.hasClass('selectBox-disabled')) return;				
 					switch (event.keyCode) {
 					case 8:
 						// backspace
@@ -407,39 +629,122 @@ if (jQuery)(function($) {
 						// esc
 						hideMenus();
 						removeHover(select);
+						control.focus();
 						break;
 					case 13:
 						// enter
 						if (control.hasClass('selectBox-menuShowing')) {
-							selectOption(select, options.find('LI.selectBox-hover:first'), event);
-							if (control.hasClass('selectBox-dropdown')) hideMenus();
+							event.preventDefault();
+							selectOption(select, lastHovered, event);
+							keepOptionInView(select, lastHovered);
+							if (control.hasClass('selectBox-dropdown'))
+							{
+								 hideMenus();
+								 control.focus();
+							}
 						} else {
 							showMenu(select);
 						}
+						break;
+					case 32:
+						// space
+						if (control.hasClass('selectBox-menuShowing')) {
+							event.preventDefault();
+							selectOption(select, lastHovered, event);
+							keepOptionInView(select, lastHovered);
+						}
+						break;
+					case 33:
+						// page up
+						event.preventDefault();
+						currentIndex = lastSelected ? lis.index(lastSelected) : lis.index(options.find('.selectBox-hover'));
+						pageHeight = control.hasClass('selectBox-dropdown') ? options.height() : control.height();
+						optionHeight = parseInt(options.find('A:first').outerHeight());
+						size = (select.attr('size')) ? parseInt(select.attr('size')) : Math.floor(pageHeight/optionHeight);
+						console.log("{pageHeight:"+pageHeight+"px, optionHeight:"+optionHeight+"px, size:"+size+"}");
+						var newIndex = Math.max(0, currentIndex-size),
+							prev = lis.eq(newIndex);
+						totalOptions = lis.length;
+						i = newIndex;
+						while (prev.length === 0 || prev.hasClass('selectBox-disabled') || prev.hasClass('selectBox-optgroup')) {
+							prev = lis.eq(i-1);
+							if (prev.length === 0 || i<=0) {
+								prev = selectableOptions.eq(0);										
+							}
+							if (--i <= 0) break;
+						}
+						addHover(select, prev);			
+						selectOption(select, prev, event);
+						keepOptionInView(select, prev);
+						break;
+					case 34:
+						// page down
+						event.preventDefault();
+						currentIndex = lastSelected ? lis.index(lastSelected) : lis.index(options.find('.selectBox-hover'));
+						pageHeight = control.hasClass('selectBox-dropdown') ? options.height() : control.height();
+						optionHeight = parseInt(options.find('A:first').outerHeight());
+						size = (select.attr('size')) ? parseInt(select.attr('size')) : Math.floor(pageHeight/optionHeight);
+						var newIndex = Math.min(lis.length-1, currentIndex+size),
+							next = lis.eq(newIndex);
+						totalOptions = lis.length;
+						i = newIndex;
+						while (next.length === 0 || next.hasClass('selectBox-disabled') || next.hasClass('selectBox-optgroup')) {
+							next = lis.eq(i+1);
+							if (next.length === 0 || i>=(totalOptions-1)) {
+								next = selectableOptions.eq(selectableOptions.length-1);										
+							}
+							if (++i >= totalOptions) break;
+						}
+						addHover(select, next);
+						selectOption(select, next, event);
+						keepOptionInView(select, next);
+						break;
+					case 35:
+						// end
+						event.preventDefault();
+						addHover(select, selectableOptions.last());			
+						selectOption(select, selectableOptions.last(), event);
+						keepOptionInView(select, selectableOptions.last());
+						break;
+					case 36:
+						// home
+						event.preventDefault();
+						addHover(select, selectableOptions.first());			
+						selectOption(select, selectableOptions.first(), event);
+						keepOptionInView(select, selectableOptions.first());
 						break;
 					case 38:
 						// up
 					case 37:
 						// left
 						event.preventDefault();
-						if (control.hasClass('selectBox-menuShowing')) {
-							var prev = options.find('.selectBox-hover').prev('LI');
-							totalOptions = options.find('LI:not(.selectBox-optgroup)').length;
-							i = 0;
+						if (control.hasClass('selectBox-menuShowing') && !event.altKey) {
+							currentIndex = lastSelected ? selectableOptions.index(lastSelected) : selectableOptions.index(options.find('.selectBox-hover'));
+							
+							if (currentIndex == 0 
+								&& (!settings.loopOptions || select.attr('multiple'))) break;
+							
+							var prev = selectableOptions.eq(currentIndex-1);
+							totalOptions = selectableOptions.length;
+							i = currentIndex-1;
 							while (prev.length === 0 || prev.hasClass('selectBox-disabled') || prev.hasClass('selectBox-optgroup')) {
-								prev = prev.prev('LI');
+								prev = selectableOptions.eq(i-1);
 								if (prev.length === 0) {
 									if (settings.loopOptions) {
-										prev = options.find('LI:last');
+										prev = selectableOptions.eq(selectableOptions.length-1);
 									} else {
-										prev = options.find('LI:first');
+										prev = selectableOptions.eq(0);
 									}
+									break;
 								}
-								if (++i >= totalOptions) break;
+								if (--i <= 0) break;
 							}
-							addHover(select, prev);
+							
+							addHover(select, prev);			
 							selectOption(select, prev, event);
 							keepOptionInView(select, prev);
+						} else if (event.altKey) {
+							hideMenus();
 						} else {
 							showMenu(select);
 						}
@@ -450,16 +755,21 @@ if (jQuery)(function($) {
 						// right
 						event.preventDefault();
 						if (control.hasClass('selectBox-menuShowing')) {
-							var next = options.find('.selectBox-hover').next('LI');
-							totalOptions = options.find('LI:not(.selectBox-optgroup)').length;
-							i = 0;
+							currentIndex = lastSelected ? selectableOptions.index(lastSelected) : selectableOptions.index(options.find('.selectBox-hover'));
+							
+							if (currentIndex == selectableOptions.length-1 
+								&& (!settings.loopOptions || select.attr('multiple'))) break;
+							
+							var next = selectableOptions.eq(currentIndex+1);
+							totalOptions = selectableOptions.length;
+							i = currentIndex+1;
 							while (next.length === 0 || next.hasClass('selectBox-disabled') || next.hasClass('selectBox-optgroup')) {
-								next = next.next('LI');
+								next = selectableOptions.eq(i+1);
 								if (next.length === 0) {
 									if (settings.loopOptions) {
-										next = options.find('LI:first');
+										next = selectableOptions.eq(0);
 									} else {
-										next = options.find('LI:last');
+										next = selectableOptions.eq(selectableOptions.length-1);										
 									}
 								}
 								if (++i >= totalOptions) break;
@@ -471,7 +781,31 @@ if (jQuery)(function($) {
 							showMenu(select);
 						}
 						break;
+					case 119:
+						// F8
+						if (multiple && event.shiftKey)
+						{
+							event.preventDefault();
+							control.toggleClass('selectBox-multiselect');
+						}
+						break;
+					
+					case 65:
+						if (multiple && ((isMac && event.metaKey) || (!isMac && event.ctrlKey)))
+						{
+							// CTRL+A
+							event.preventDefault();
+							event.stopPropagation();
+							selectableOptions.not(lastHovered).each(function(index, element) {
+								selectOption(select, $(element), event);
+							});
+							addHover(select, lastHovered);
+							selectOption(select, lastHovered, event);
+							keepOptionInView(select, lastHovered);
+						}
+						break;
 					}
+					
 				};
 			var handleKeyPress = function(select, event) {
 					//
@@ -479,7 +813,15 @@ if (jQuery)(function($) {
 					//
 					select = $(select);
 					var control = select.data('selectBox-control'),
-						options = control.data('selectBox-options');
+						options = control.data('selectBox-options'),
+						i = 0,
+						start = 0,
+						o,
+						label,
+						found = false,
+						selectableOptions = options.find('LI:not(.selectBox-optgroup, .selectBox-disabled)'),
+						lastHovered = options.find('.selectBox-hover'),
+						newString = String.fromCharCode(event.charCode || event.keyCode);
 					if (control.hasClass('selectBox-disabled')) return;
 					switch (event.keyCode) {
 					case 9:
@@ -488,6 +830,8 @@ if (jQuery)(function($) {
 						// esc
 					case 13:
 						// enter
+					case 32:
+						// space
 					case 38:
 						// up
 					case 37:
@@ -503,14 +847,41 @@ if (jQuery)(function($) {
 						if (!control.hasClass('selectBox-menuShowing')) showMenu(select);
 						event.preventDefault();
 						clearTimeout(typeTimer);
-						typeSearch += String.fromCharCode(event.charCode || event.keyCode);
-						options.find('A').each(function() {
-							if ($(this).text().substr(0, typeSearch.length).toLowerCase() === typeSearch.toLowerCase()) {
-								addHover(select, $(this).parent());
-								keepOptionInView(select, $(this).parent());
-								return false;
+						typeSearch += newString!=typeSearch ? newString : '';					
+						for (i=0; i<selectableOptions.length; i++)
+						{
+							o = selectableOptions.eq(i);
+							if (o.is(lastHovered)) {
+								start = (typeSearch.length==1) ? i+1 : i;
+								break;
 							}
-						});
+						}
+						
+						for (i = start; i < selectableOptions.length; i++) {
+							o = selectableOptions.eq(i);
+							label = o.text();
+							if (label.substring(0, typeSearch.length).toLowerCase() === typeSearch.toLowerCase())
+							{
+								found = true;
+								addHover(select, o);
+								keepOptionInView(select, o);
+								break;
+							}
+						}
+						if (!found)
+						{
+							for (i = 0; i < start; i++) {
+								o = selectableOptions.eq(i);
+								label = o.text();
+								if (label.substring(0, typeSearch.length).toLowerCase() === typeSearch.toLowerCase())
+								{
+									addHover(select, o);
+									keepOptionInView(select, o);
+									break;
+								}
+							}
+						}
+
 						// Clear after a brief pause
 						typeTimer = setTimeout(function() {
 							typeSearch = '';
@@ -523,14 +894,14 @@ if (jQuery)(function($) {
 					select.attr('disabled', false);
 					var control = select.data('selectBox-control');
 					if (!control) return;
-					control.removeClass('selectBox-disabled');
+					control.removeClass('selectBox-disabled').removeAttr('aria-disabled');
 				};
 			var disable = function(select) {
 					select = $(select);
 					select.attr('disabled', true);
 					var control = select.data('selectBox-control');
 					if (!control) return;
-					control.addClass('selectBox-disabled');
+					control.addClass('selectBox-disabled').attr('aria-disabled',true);
 				};
 			var setValue = function(select, value) {
 					select = $(select);
@@ -547,17 +918,17 @@ if (jQuery)(function($) {
 					// Update label
 					setLabel(select);
 					// Update control values
-					options.find('.selectBox-selected').removeClass('selectBox-selected');
+					options.find('.selectBox-selected').removeClass('selectBox-selected').find('A').removeAttr('aria-selected');
 					options.find('A').each(function() {
 						if (typeof(value) === 'object') {
 							for (var i = 0; i < value.length; i++) {
 								if ($(this).attr('rel') == value[i]) {
-									$(this).parent().addClass('selectBox-selected');
+									$(this).attr('aria-selected',true).parent().addClass('selectBox-selected');
 								}
 							}
 						} else {
 							if ($(this).attr('rel') == value) {
-								$(this).parent().addClass('selectBox-selected');
+								$(this).attr('aria-selected',true).parent().addClass('selectBox-selected');
 							}
 						}
 					});
@@ -602,26 +973,30 @@ if (jQuery)(function($) {
 					case 'dropdown':
 						// Update label
 						setLabel(select);
-						$("BODY").append(options);
+						options.insertAfter(control);
 						break;
 					}
 				};
 			var disableSelection = function(selector) {
-					$(selector).css('MozUserSelect', 'none').bind('selectstart', function(event) {
+					$(selector)
+					.css({'MozUserSelect': 'none', 'WebkitUserSelect': 'none', 'MsUserSelect': 'none', 'OUserSelect':'none'})
+					.bind('selectstart', function(event) {
 						event.preventDefault();
 					});
 				};
-			var generateOptions = function(self, options) {
-					var li = $('<li />'),
-						a = $('<a />');
+			var generateOption = function(self, parentNode) {
+					var li = $('<li role="presentation" />'),
+						a = $('<a role="option" />');
 					li.addClass(self.attr('class'));
 					li.data(self.data());
 					a.attr('rel', self.val()).text(self.text());
 					li.append(a);
-					if (self.attr('disabled')) li.addClass('selectBox-disabled');
-					if (self.attr('selected')) li.addClass('selectBox-selected');
-					options.append(li);
+					if (self.attr('disabled')) li.addClass('selectBox-disabled').find('A').attr('aria-disabled',true);
+					if (self.attr('selected')) li.addClass('selectBox-selected').find('A').attr('aria-selected',true);
+					parentNode.append(li);
+					return li;
 				};
+
 			//
 			// Public methods
 			//


### PR DESCRIPTION
Implement WAI-ARIA combobox/listbox design patterns to improve
accessibility for keyboard-only users and users of assistive technology.

http://www.w3.org/WAI/PF/aria-practices/#combobox
http://www.w3.org/WAI/PF/aria-practices/#Listbox

Improved behavior of keyboard-only multiselect.

Added keyboard support for home, end, page_up, page_down, ctrl+a to
select all, space bar, alt+down_arrow, alt+up_arrow, and the obscure,
yet useful, shift+f8 multiselect toggle.
