### PR TITLE
Fix type-to-find behaviour

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -507,6 +507,7 @@ if (jQuery)(function($) {
 						options.find('A').each(function() {
 							if ($(this).text().substr(0, typeSearch.length).toLowerCase() === typeSearch.toLowerCase()) {
 								addHover(select, $(this).parent());
+								selectOption(select, $(this).parent(), event);
 								keepOptionInView(select, $(this).parent());
 								return false;
 							}


### PR DESCRIPTION
To be consistent with standard UI behaviour, typing a value should automatically select that value, not just highlight it in the list.

(note: this pull request does not include a new minified version of the script)
