### PR TITLE
Fix init parameters

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -671,7 +671,7 @@ if (jQuery)(function($) {
 				break;
 			default:
 				$(this).each(function() {
-					init(this, method);
+					init(this, data);
 				});
 				break;
 			}


### PR DESCRIPTION
Init call was being given method name instead of settings data.
