### PR TITLE
Update jquery.selectBox.js

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -224,10 +224,17 @@ if (jQuery)(function($) {
 					hideMenus();
 					var borderBottomWidth = isNaN(control.css('borderBottomWidth')) ? 0 : parseInt(control.css('borderBottomWidth'));
 					// Menu position
-					options.width(control.innerWidth()).css({
-						top: control.offset().top + control.outerHeight() - borderBottomWidth,
-						left: control.offset().left
-					});
+					if(settings.menuAbove) {
+			                        options.width(control.innerWidth()).css({
+			                            top: control.offset().top - options.height() - borderBottomWidth,
+			                            left: control.offset().left
+			                        });
+			                } else {
+			                        options.width(control.innerWidth()).css({
+			                            top: control.offset().top + control.outerHeight() - borderBottomWidth,
+			                            left: control.offset().left
+			                        });
+			                }
 					if (select.triggerHandler('beforeopen')) return false;
 					var dispatchOpenEvent = function() {
 							select.triggerHandler('open', {


### PR DESCRIPTION
Calling selectBox with the option menuAbove you can show the menu on the top of the select instead of the bottom of it.
Useful if you have a styled select box on the bottom of the page.

Es:
$('select').selectBox({menuAbove: true});
