### PR TITLE
`setOptions` now depends on `refresh` and not vice-versa

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 
             $('#refresh').click(function() {
                 $('SELECT OPTION').each(function() {
-                    $(this).text($(this).text().replace("Item", "Value"));
+                    $(this).text('Refreshed ' + $(this).val());
                 });
                 $('SELECT').selectBox('refresh');
             });

--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -425,7 +425,7 @@
         }
 
         // Restore opened dropdown state (original menu was trashed)
-        if (type == 'dropdown' && control.hasClass('selectBox-menuShowing')) {
+        if ('dropdown' === type && control.hasClass('selectBox-menuShowing')) {
             this.showMenu();
         }
     };


### PR DESCRIPTION
Separated `setOptions` method logic into two parts:
- updating underlying SELECT element options (stayed in setOptions)
- updating SelectBox control based on the SELECT options (moved to
  `refresh` method)

Method `refresh` now contains all the logic necessary to refresh the
control and no longer uses `setOptions`. Method `setOptions` is calling
`refresh` to update the SelectBox control.

Fixes marcj/jquery-selectBox#88.
