### PR TITLE
Fix for issue #121

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -813,7 +813,8 @@
     SelectBox.prototype.handleKeyPress = function (event) {
         var select = $(this.selectElement)
             , control = select.data('selectBox-control')
-            , options = control.data('selectBox-options');
+            , options = control.data('selectBox-options')
+            , self    = this;
 
         if (control.hasClass('selectBox-disabled')) {
             return;
@@ -845,16 +846,16 @@
                 clearTimeout(this.typeTimer);
                 this.typeSearch += String.fromCharCode(event.charCode || event.keyCode);
                 options.find('A').each(function () {
-                    if ($(this).text().substr(0, this.typeSearch.length).toLowerCase() === this.typeSearch.toLowerCase()) {
-                        this.addHover($(this).parent());
-                        this.selectOption($(this).parent(), event);
-                        this.keepOptionInView($(this).parent());
+                    if ($(this).text().substr(0, self.typeSearch.length).toLowerCase() === self.typeSearch.toLowerCase()) {
+                        self.addHover($(this).parent());
+                        self.selectOption($(this).parent(), event);
+                        self.keepOptionInView($(this).parent());
                         return false;
                     }
                 });
                 // Clear after a brief pause
                 this.typeTimer = setTimeout(function () {
-                    this.typeSearch = '';
+                    self.typeSearch = '';
                 }, 1000);
                 break;
         }


### PR DESCRIPTION
In handleKeyPress method, I've added a 'self' variable pointing to 'this':

``` javascript
SelectBox.prototype.handleKeyPress = function (event) {
    var select = $(this.selectElement)
        , control = select.data('selectBox-control')
        , options = control.data('selectBox-options')
        , self    = this;
```

And below, in the default part of the switch, I've replaced some 'this' references to 'self' references, as they were out of context:

``` javascript
options.find('A').each(function () {
      if ($(this).text().substr(0, self.typeSearch.length).toLowerCase() === self.typeSearch.toLowerCase()) {
          self.addHover($(this).parent());
          self.selectOption($(this).parent(), event);
          self.keepOptionInView($(this).parent());
          return false;
      }
  });
  // Clear after a brief pause
  this.typeTimer = setTimeout(function () {
      self.typeSearch = '';
  }, 1000);
```
