### PR TITLE
Bugfix "elem.style is undefined"

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -452,7 +452,7 @@
         
         // Get top or bottom position for menu
         var top = control.offset().top + control.outerHeight() - borderBottomWidth
-            , posTop = top+options.outerHeight()>$(window).outerHeight();
+            , posTop = top+options.outerHeight()>$(window).height();
         top = posTop?control.offset().top - options.outerHeight() + borderTopWidth:top;
 
         // Save if position is top to options data


### PR DESCRIPTION
In jQuery version 1.6.1 when using <code>$(window).outerHeight()</code>, it results in an error stating "elem.style is undefined" or "a.style is undefined"
Changing to <code>$(window).height()</code> fixed the error. 
It is because the Window object has no property called "style"
