### PR TITLE
Use jQuery's .prop() and add disableAutoStyle option

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -1042,7 +1042,7 @@
         if (self.attr('disabled')) {
             li.addClass('selectBox-disabled');
         }
-        if (self.attr('selected')) {
+        if (self.prop('selected')) {
             li.addClass('selectBox-selected');
         }
         options.append(li);

--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -28,10 +28,10 @@
         this.typeTimer     = null;
         this.typeSearch    = '';
         this.isMac         = navigator.platform.match(/mac/i);
-        options            = 'object' === typeof options ? options :  {};
+        this.options       = options = 'object' === typeof options ? options :  {};
         this.selectElement = select;
 
-        // Disable for iOS devices (their native controls are more suitable for a touch device)
+        // Disable for mobile devices (their native controls are more suitable for a touch device)
         if (!options.mobile && navigator.userAgent.match(/iPad|iPhone|Android|IEMobile|BlackBerry/i)) {
             return false;
         }
@@ -67,11 +67,11 @@
             , self     = this;
 
         control
-            .width(select.outerWidth())
+            .width(settings.disableAutoStyle ? '' : select.outerWidth())
             .addClass(select.attr('class'))
             .attr('title', select.attr('title') || '')
             .attr('tabindex', tabIndex)
-            .css('display', 'inline-block')
+            .css('display', settings.disableAutoStyle ? '' : 'inline-block')
             .bind('focus.selectBox', function () {
                 if (this !== document.activeElement && document.body !== document.activeElement) {
                     $(document.activeElement).blur();
@@ -209,7 +209,7 @@
                   - (parseInt(label.css('paddingLeft')) || 0)
                   - (parseInt(label.css('paddingRight')) || 0);
 
-            label.width(labelWidth);
+            label.width(this.options.disableAutoStyle ? '' : labelWidth);
             this.disableSelection(control);
         }
         // Store data for later use and show the control

--- a/readme.md
+++ b/readme.md
@@ -44,12 +44,13 @@ $('select').selectBox({
 
 ## Settings
 
-| Key            | Default       | Values                     |  Description                                     |
-| ---------------|:-------------:|---------------------------:|-------------------------------------------------:|
-| mobile         | `false`       | Boolean                    | Disables the widget for mobile devices           |
-| menuTransition | `default`     | `default`, `slide`, `fade` | The show/hide transition for dropdown menus      |
-| menuSpeed      | `normal`      | `slow`, `normal`, `fast`   | The show/hide transition speed                   |
-| loopOptions    | `false`       | Boolean                    | Flag to allow arrow keys to loop through options |
+| Key                 | Default       | Values                     |  Description                                     |
+| --------------------|:-------------:|---------------------------:|-------------------------------------------------:|
+| mobile              | `false`       | Boolean                    | Disables the widget for mobile devices           |
+| menuTransition      | `default`     | `default`, `slide`, `fade` | The show/hide transition for dropdown menus      |
+| menuSpeed           | `normal`      | `slow`, `normal`, `fast`   | The show/hide transition speed                   |
+| loopOptions         | `false`       | Boolean                    | Flag to allow arrow keys to loop through options |
+| disableAutoStyle    | `false`       | Boolean                    | Disables setting inline styles                   |
 
 
 To specify settings after the init, use this syntax:


### PR DESCRIPTION
As of jQuery 1.6 element properties should be accessed with jQuery's .prop() method (715a34623390fdc706968e4666d060e29728cd4f)

When coming from an earlier jQuery-selectBox version (I came from 1.0.6) setting inline styles overwrites existing css definitions. (4773a31efb48bac537e40f3df1174b7fbbc9cc1f)
