### PR TITLE
Fix number of l's and r's in correlation

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -457,7 +457,7 @@
         // Get proper variables for keeping options in viewport
         var pos = control.offset()
             , topPositionCorrelation = (settings.topPositionCorrelation) ? settings.topPositionCorrelation : 0
-            , bottomPositionCorrelation = (settings.bottomPositionCorellation) ? settings.bottomPositionCorellation : 0
+            , bottomPositionCorrelation = (settings.bottomPositionCorrelation) ? settings.bottomPositionCorrelation : 0
             , optionsHeight = options.outerHeight()
             , controlHeight = control.outerHeight()
             , maxHeight = parseInt(options.css('max-height'))


### PR DESCRIPTION
The option as listed in the README didn't work because correlation was spelled incorrectly in two spots in the source.
