### PR TITLE
Fix syntax to be independent of line-breaks

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -42,7 +42,7 @@
         }
 
         this.init(options);
-    }
+    };
 
     /**
      * @type {String}
@@ -593,7 +593,7 @@
                 $(this).removeClass('selectBox-menuShowing selectBox-menuShowing-'+(posTop?'top':'bottom'));
             }
             
-            options.css('max-height','')
+            options.css('max-height','');
             //Remove Top or Bottom class based on position
             options.removeClass('selectBox-options-'+(posTop?'top':'bottom'));
             options.data('posTop' , false);


### PR DESCRIPTION
When packing the JS source, 2 syntax errors arise that are caused by implicit semicolons which depend on line breaks. Since the packer removes these line breaks, the code will no longer work. You can try this yourself here: http://dean.edwards.name/packer/
The errors are:

```
Syntax error at line 95 while loading: expected ';', got 'k'
 false}this.init(b)}k.prototype.version=
```

```
Syntax error at line 95 while loading: expected ';', got 'a'
css('max-height','')a.removeClass('selectBox-
```

This commit fixes both of them. :)

Cheers,
Steffen
