### PR TITLE
Remove deprecated andSelf that caused error on blur.

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -548,7 +548,7 @@
 
         $(document).bind('mousedown.selectBox', function (event) {
             if (1 === event.which) {
-                if ($(event.target).parents().andSelf().hasClass('selectBox-options')) {
+                if ($(event.target).parents().addBack().hasClass('selectBox-options')) {
                     return;
                 }
                 self.hideMenus();


### PR DESCRIPTION
Using the deprecated `andSelf` is causing an error when the selectBox is blurred. Switched with the updated `addBack` method solves the issue and clears the error.