### PR TITLE
Update for jQuery 3:  addBack() in place of andSelf()

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -548,7 +548,7 @@
 
         $(document).bind('mousedown.selectBox', function (event) {
             if (1 === event.which) {
-                if ($(event.target).parents().andSelf().hasClass('selectBox-options')) {
+		if ($(event.target).parents().addBack().hasClass('selectBox-options')) {
                     return;
                 }
                 self.hideMenus();


### PR DESCRIPTION
As pointed out by @akurfuerst and @Seoptics (see https://github.com/marcj/jquery-selectBox/issues/180),
andSelf() is removed in jquery 3, see https://jquery.com/upgrade-guide/3.0/#breaking-change-andself-removed-use-addback